### PR TITLE
Changes for the headline structure of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Before you start, Clone / fork this repository and go into the folder.
 There are two ways of using this tool: With [Vagrant](#Vagrant) or [Docker](#Docker).
 
 
-# Vagrant
+## Vagrant
 Download and install [Vagrant](https://www.vagrantup.com/downloads).
 
-## Requirements
+### Requirements
 - PHP 7.0
 - Sqlite
 - A (maybe big) list of urls to crawl. Robots.txt and Sitemaps detected automatically
 
-## Installation
+### Installation
 
 1. Run:
 ```composer install```
@@ -26,7 +26,7 @@ Download and install [Vagrant](https://www.vagrantup.com/downloads).
 
 ```cp config.sample.php config.php```
 
-# Usage
+### Usage
 
 Create a .csv which contains a list of urls to iterate over (see example.csv).
 
@@ -58,7 +58,7 @@ Whilst debugging, increase verbosity by adding a number of `-v` flags.
 `-vv` : very verbose
 `-vvv` : debug
 
-# Configuration
+### Configuration
 
 There are some settings that you can configure, like the headers that you'll send to the site or the concurrency that you want to use.
 


### PR DESCRIPTION
The readme had an incoherent headline structure which made the comprehension a bit difficult.  It was cumbersome to distinguish between the `vagrant` part and the `docker` part due to the fact the `vagrant` was an `h1` while `docker` was an `h2`.  right before the docker part there were the `configuration` and `usage` parts which were also an `h1` making the impression that all steps might be necessary even though you just want to use the `docker` part. instead they are two complete different processes.
therefor i would suggest make the vagrant and docker headlines each a `h2` so the only `h1` in the document is the `visual regression testing made easy`. also making  all the sub headlines of `vagrant` and `docker`  a `h3`. that would be a quick and easy fix to make the readme a bit easier to comprehend.