### PR TITLE
Prevent warning on empty variable in case of no previous crawl run.

### DIFF
--- a/src/ScraperBot/Routing/Controllers/ResultChangedController.php
+++ b/src/ScraperBot/Routing/Controllers/ResultChangedController.php
@@ -75,7 +75,7 @@ class ResultChangedController {
 
         // Get the list of results, per site, for a given timestamp and prepare
         // array entries representing the rows.
-        if (sizeof($crawlResults[$crawls[1]]) > 1) {
+        if (!empty($crawls[1]) && sizeof($crawlResults[$crawls[1]]) > 1) {
             foreach ($crawlResults[$crawls[0]] as $url => $site) {
                 if ($crawlResults[$crawls[1]][$site['url']]['statusCode'] != $site['statusCode']) {
 


### PR DESCRIPTION
Fixing warning. See attached screenshot. To reproduce, you need to have only ever run 1 crawl.
![image](https://user-images.githubusercontent.com/1541667/113326409-e62b6080-9319-11eb-81cc-caedc4cf4fcc.png)
