### PR TITLE
GBOT-1002: Cache buster issue has been fixed.

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,6 @@ COMPOSE_FILE=glitcherbot_docker/docker-compose.yml
 PROJECT_NAME=glitcherbot
 PROJECT_BASE_URL=localhost
 PROJECT_PORT=8089
+
+# Cache Buster variable set to yes/FALSE
+CACHE_BUSTER=FALSE

--- a/src/ScraperBot/Command/Acquia/AcsfCrawlSitesCommand.php
+++ b/src/ScraperBot/Command/Acquia/AcsfCrawlSitesCommand.php
@@ -28,8 +28,8 @@ class AcsfCrawlSitesCommand extends CrawlSitesCommand {
             ->addOption('destination_folder', null, InputArgument::OPTIONAL, 'Path to the destination folder for results', '.')
             ->addOption('use_base_uri', null, InputOption::VALUE_NONE, 'If specified, ask guzzle to create a new client each time, in order to specify base URI for redirects.')
             ->addOption('include_sitemaps', null, InputArgument::OPTIONAL, 'Crawl urls found in sitemaps', FALSE)
-            ->addOption('force_sitemaps', null, InputArgument::OPTIONAL, 'Force indexing sitemaps even if not found in robots.txt', FALSE);
-
+            ->addOption('force_sitemaps', null, InputArgument::OPTIONAL, 'Force indexing sitemaps even if not found in robots.txt', FALSE)
+            ->addOption('cache_buster', null, InputArgument::OPTIONAL, 'Adds an argument on urls to force cache busting', FALSE);
     }
 
     /**

--- a/src/ScraperBot/Command/CrawlSitesCommand.php
+++ b/src/ScraperBot/Command/CrawlSitesCommand.php
@@ -28,6 +28,7 @@ class CrawlSitesCommand extends GlitcherBotCommand {
     private $use_base_uri = FALSE;
     private $include_sitemaps = FALSE;
     private $force_sitemaps = FALSE;
+    private $cache_buster = FALSE;
 
     private $input = NULL;
     private $output = NULL;
@@ -133,7 +134,7 @@ class CrawlSitesCommand extends GlitcherBotCommand {
 
                 $pendingSource = new SitesArraySource($pendingURLs);
 
-                $this->crawler->crawlSites($pendingSource, $this->default_client, $this->default_config, $timestamp, FALSE, $sitemaps);
+                $this->crawler->crawlSites($pendingSource, $this->default_client, $this->default_config, $timestamp, FALSE, $sitemaps, $this->cache_buster);
             }
         }
 

--- a/src/ScraperBot/Crawler.php
+++ b/src/ScraperBot/Crawler.php
@@ -32,6 +32,8 @@ class Crawler {
 
     private $output = NULL;
 
+    private $offIndex = 0;
+
     /**
      * Crawler constructor.
      * @param StorageInterface $storage
@@ -97,20 +99,20 @@ class Crawler {
 
         $urls = $event->getUrls();
 
-        $cacheBuster = '';
+        $cacheBusterString = '';
         if ($cacheBuster == 'yes') {
-            $cacheBuster = '?' . $this->generateCacheBuster();
+            $cacheBusterString = '?' . $this->generateCacheBuster();
         }
 
         if (!isset($timestamp)) {
             $timestamp = time();
         }
 
-        $promises = (function () use ($urls, $client, $default_config, $timestamp, $assumeTimestamp, $forceSitemaps, $cacheBuster) {
+        $promises = (function () use ($urls, $client, $default_config, $timestamp, $assumeTimestamp, $forceSitemaps, $cacheBusterString) {
             foreach ($urls as $url) {
                 if (!empty($url)) {
                     // Add a cache buster.
-                    $target_url = $url . $cacheBuster;
+                    $target_url = $url . $cacheBusterString;
 
                     // If default config is provided, create a new client each time.
                     if ($default_config != NULL) {

--- a/src/templates/crawls_diffs.twig
+++ b/src/templates/crawls_diffs.twig
@@ -22,7 +22,7 @@
                     {% for header in headers %}
                         <th>Size</th>
                         <th>Status Code</th>
-                        <th>url</th>
+                        <th>URL</th>
                     {%  endfor %}
                 </tr>
             </thead>

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -27,7 +27,7 @@
                 <ol><code>make crawl SITES_CSV=sitesd8-prod.json</code></ol>
             </li>
             <li>Using Acquia's json:
-                <ol><code>make crawl-acquia SITES_JSON=sitesd8-prod.json</code></ol>
+                <ol><code>make crawl-acquia SITES_JSON=sitesd8-prod.json INCLUDE_SITEMAPS=yes FORCE_SITEMAPS=no</code></ol>
             </li>
         </ul>
         

--- a/src/templates/results.twig
+++ b/src/templates/results.twig
@@ -37,7 +37,7 @@
                     {{ loop.index }}
                 </td>
                 {%  for column in row %}
-                    <td {% if column.2 %}class="table-danger"{% endif %}>
+                    <td {% if column.2 %}class="table-danger"{% endif %} style="text-align:left;">
                         <a href="/stats/site?url={{ column.3 }}">{{ column.3 }}</a>
                     </td>
                     <td {% if column.2 %}class="table-danger"{% endif %}>

--- a/src/templates/results_changed_to_errors.twig
+++ b/src/templates/results_changed_to_errors.twig
@@ -36,7 +36,7 @@
                     {{ loop.index }}
                 </td>
                 {%  for key2, column in row %}
-                    <td {% if column.2 %}class="table-danger"{% endif %}>
+                    <td {% if column.2 %}class="table-danger"{% endif %} style="text-align:left;">
                         <a href="/stats/site?url={{ column.3 }}">{{ column.3 }}</a>
                     </td>
                     <td {% if column.2 %}class="table-danger"{% endif %}>

--- a/src/templates/results_site_stats.twig
+++ b/src/templates/results_site_stats.twig
@@ -24,7 +24,7 @@
                 <th>url</th>
                 <th>Size</th>
                 <th>Status Code</th>
-                <th style="width: 60%">Tags</th>
+                <th style="width: 50%">Tags</th>
             {%  endfor %}
         </tr>
         </thead>
@@ -46,6 +46,8 @@
                     </td>
 
                     <td style="text-align:left" {% if column.2 %}class="table-danger"{% endif %}>
+                        <b>Total tags: {{ column.4['total'] }}</b>
+                        <br><br>
                         {%  for key, tag in column.4 %}
                             {% if key != 'total' %}
                                 <b>&lt;{{ key }}&gt;</b> {{ tag }}<br>

--- a/src/templates/tolerance_form.twig
+++ b/src/templates/tolerance_form.twig
@@ -28,7 +28,7 @@
                         <option value="{{ header|date('F d, Y H:i:s') }}">{{ header|date('F d, Y H:i:s') }}</option>
                     {%  endfor %}
                 </select>
-                <input type="submit">
+                <input type="submit"> <input type="reset">
             </form>
         </div>
     </form>


### PR DESCRIPTION
- `CacheBuster` Variable value defined in `.env`. Default value set to `FALSE`.
- Optional Argument missing in Class `AcsfCrawlSitesCommand` & `CrawlSitesCommand`
- Fix condition for `cacheBuster` always failed with empty value as Parameter and Variable name same
- Undefined variable added `offIndex` to `Class Crawler`
- updated twig templates - Minor changes